### PR TITLE
NEW Add readonly transformation state for link field

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -14,4 +14,8 @@ en:
       other: '{count} files'
     SINGULARNAME: file
   SilverStripe\ElementalBlocks\Form\BlockLinkField:
+    Description: 'Link description'
     Empty: Empty
+    LinkText: 'Link text'
+    SelectPage: 'Select a page'
+    TargetBlank: 'Open in a new window/tab'

--- a/src/Form/BlockLinkField.php
+++ b/src/Form/BlockLinkField.php
@@ -67,14 +67,28 @@ class BlockLinkField extends FormField
     }
 
     /**
+     * Get the linked {@link SiteTree} object, if available
+     *
+     * @return SiteTree|null
+     */
+    public function getLinkPage()
+    {
+        $pageId = (int) $this->getParsedValue()->PageID;
+        if (!$pageId) {
+            return null;
+        }
+
+        return DataObject::get_by_id(SiteTree::class, $pageId);
+    }
+
+    /**
      * Get the relative URL for the linked {@link SiteTree} object, with a leading slash
      *
      * @return string
      */
     public function getLinkRelativeUrl()
     {
-        /** @var SiteTree $page */
-        $page = DataObject::get_by_id(SiteTree::class, $this->getParsedValue()->PageID);
+        $page = $this->getLinkPage();
 
         return $page ? '/' . ltrim($page->URLSegment, '/') : '';
     }

--- a/src/Form/BlockLinkField_Readonly.php
+++ b/src/Form/BlockLinkField_Readonly.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SilverStripe\ElementalBlocks\Form;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\CheckboxField_Readonly;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\ReadonlyField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\ToggleCompositeField;
+use SilverStripe\Forms\TreeDropdownField;
+
+/**
+ * Readonly version of a {@link BlockLinkField} field, which displays the data fields as readonly text
+ * inputs and a checkbox for "target blank".
+ */
+class BlockLinkField_Readonly extends ReadonlyField
+{
+    public function Field($properties = [])
+    {
+        /** @var BlockLinkField $originalField */
+        $originalField = BlockLinkField::create('TempReadonly')->setValue($this->value);
+
+        $name = $this->getName();
+
+        $fields = FieldList::create();
+
+        $fields->push(
+            TreeDropdownField::create($name . '_PageID', null, SiteTree::class)
+                ->setTitle(_t('SilverStripe\\ElementalBlocks\\Form\\BlockLinkField.SelectPage', 'Select a page'))
+                ->setValue($originalField->getParsedValue()->PageID)
+                ->performReadonlyTransformation()
+        );
+
+        if ($originalField->getShowLinkText()) {
+            $fields->push(
+                $this->castedCopy(TextField::class)
+                    ->setName($name . '_Text')
+                    ->setTitle(_t('SilverStripe\\ElementalBlocks\\Form\\BlockLinkField.LinkText', 'Link text'))
+                    ->setValue($originalField->getLinkText())
+            );
+        }
+
+        $fields->push(
+            $this->castedCopy(TextField::class)
+                ->setName($name . '_Description')
+                ->setTitle(_t('SilverStripe\\ElementalBlocks\\Form\\BlockLinkField.Description', 'Link description'))
+                ->setValue($originalField->getLinkDescription())
+        );
+
+        $fields->push(
+            $this->castedCopy(CheckboxField_Readonly::class)
+                ->setName($name . '_TargetBlank')
+                ->setTitle(
+                    _t('SilverStripe\\ElementalBlocks\\Form\\BlockLinkField.TargetBlank', 'Open in a new window/tab')
+                )
+                ->setValue($originalField->getLinkTargetBlank())
+        );
+
+        $fields->each(function ($field) {
+            $field->setReadonly(true);
+        });
+
+        return ToggleCompositeField::create($name . '_Readonly', $this->Title(), $fields);
+    }
+
+    /**
+     * Do not render a form field holder for this, just display the toggled composite field
+     *
+     * {@inheritDoc}
+     */
+    public function FieldHolder($properties = [])
+    {
+        return $this->Field($properties);
+    }
+}

--- a/tests/Form/BlockLinkField_ReadonlyTest.php
+++ b/tests/Form/BlockLinkField_ReadonlyTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SilverStripe\ElementalBlocks\Tests\Form;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ElementalBlocks\Form\BlockLinkField;
+use SilverStripe\ElementalBlocks\Form\BlockLinkField_Readonly;
+use SilverStripe\Forms\CheckboxField_Readonly;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\ToggleCompositeField;
+use SilverStripe\Forms\TreeDropdownField_Readonly;
+
+class BlockLinkField_ReadonlyTest extends SapphireTest
+{
+    protected static $fixture_file = 'BlockLinkFieldTest.yml';
+
+    /**
+     * @var BlockLinkField_Readonly
+     */
+    protected $field;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->field = (new BlockLinkField('Foo'))
+            ->setValue(json_encode([
+                'PageID' => $this->idFromFixture(SiteTree::class, 'a_page'),
+                'Text' => 'Some text here',
+                'Description' => 'Do not touch the monkey',
+                'TargetBlank' => true,
+            ]))
+            ->performReadonlyTransformation();
+    }
+
+    public function testReadonlyFieldIsReturnedFromTransformation()
+    {
+        $this->assertInstanceOf(BlockLinkField_Readonly::class, $this->field);
+    }
+
+    public function testFieldReturnsToggleComposite()
+    {
+        $result = $this->field->Field();
+        $this->assertInstanceOf(ToggleCompositeField::class, $result, 'Composite fields are housed in a toggle field');
+    }
+
+    public function testFieldsByNameAreAccessibleAndCorrectType()
+    {
+        $readonlyField = $this->field->Field();
+
+        $pageId = $readonlyField->fieldByName('Foo_PageID');
+        $this->assertInstanceOf(TreeDropdownField_Readonly::class, $pageId, 'Page selector is a tree dropdown');
+        $this->assertSame($this->idFromFixture(SiteTree::class, 'a_page'), $pageId->Value());
+    }
+
+    public function testAllFieldsAreReadonly()
+    {
+        // There is no spoon
+        $fields = $this->field->Field()->FieldList();
+
+        $this->assertInstanceOf(FieldList::class, $fields);
+
+        foreach ($fields as $field) {
+            $this->assertTrue($field->isReadonly());
+        }
+    }
+}


### PR DESCRIPTION
Adds readonly state for the BlockLinkField, used for history views:

![image](https://user-images.githubusercontent.com/5170590/31981197-21d8ec4a-b9ae-11e7-9a35-30da1a6c2fa8.png)

## Blockers

- [x] https://github.com/silverstripe/silverstripe-elemental-blocks/pull/13
- [x] https://github.com/silverstripe/silverstripe-framework/pull/7512

Resolves #10 