### PR TITLE
FIX Add table_name properties to File and Banner blocks

### DIFF
--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -24,6 +24,8 @@ class BannerBlock extends FileBlock
 
     private static $plural_name = 'banners';
 
+    private static $table_name = 'S_EB_BannerBlock';
+
     public function getType()
     {
         return _t(__CLASS__ . '.BlockType', 'Banner');

--- a/src/Block/FileBlock.php
+++ b/src/Block/FileBlock.php
@@ -24,6 +24,8 @@ class FileBlock extends BaseElement
 
     private static $icon = 'font-icon-block-file';
 
+    private static $table_name = 'S_EB_FileBlock';
+
     public function getType()
     {
         return _t(__CLASS__ . '.BlockType', 'File');


### PR DESCRIPTION
Fixes #28 

This now throws a user warning, which breaks CI builds - see https://github.com/silverstripe/silverstripe-framework/issues/6904