### PR TITLE
FIX Use active TinyMCEConfig instead of a specific instance

### DIFF
--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -4,9 +4,7 @@ namespace SilverStripe\ElementalBlocks\Block;
 
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Convert;
-use SilverStripe\ElementalBlocks\Form\BlockLinkField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\Requirements;
@@ -46,7 +44,7 @@ class BannerBlock extends FileBlock
         });
 
         // Ensure TinyMCE's javascript is loaded before the blocks overrides
-        Requirements::javascript(TinyMCEConfig::get('cms')->getScriptURL());
+        Requirements::javascript(TinyMCEConfig::get()->getScriptURL());
         Requirements::javascript('silverstripe/elemental-blocks:client/dist/js/bundle.js');
         Requirements::css('silverstripe/elemental-blocks:client/dist/styles/bundle.css');
 

--- a/tests/Block/BannerBlockTest.php
+++ b/tests/Block/BannerBlockTest.php
@@ -21,7 +21,7 @@ class BannerBlockTest extends SapphireTest
         $javascript = Requirements::backend()->getJavascript();
 
         // Ensure TinyMCE's scripts are loaded first
-        $mcePath = TinyMCEConfig::get('cms')->getScriptURL();
+        $mcePath = TinyMCEConfig::get()->getScriptURL();
         $this->assertArrayHasKey($mcePath, $javascript, 'TinyMCE is loaded first');
 
         // By pushing the bundle reference again, the size of the requirements shouldn't change


### PR DESCRIPTION
This causes issues when a user has a different TinyMCEConfig instance to the default, e.g. in CWP

Fixes #34 and https://github.com/silverstripe/cwp-core/issues/16