### PR TITLE
DOCS update deprecation notice with more helpful pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This repository contains a base set of CMS content blocks for the [silverstripe-
 
 ## Warning: deprecated!
 
-For ease of maintenance and the ability for developers to individually select functionality, this module was split into two separate ones containing the functionality of each of the contained blocks.
+For ease of maintenance and the ability for developers to individually select functionality, this module was split into two.
 
 For SilverStripe 4.2 or newer, please use one or both of the following modules instead:
 
 * [silverstripe/elemental-fileblock](https://github.com/silverstripe/silverstripe-elemental-fileblock)
 * [silverstripe/elemental-bannerblock](https://github.com/silverstripe/silverstripe-elemental-bannerblock)
 
-As a replacement for this module during an upgrade, there is now also a recipe that re-combines the content blocks into a single requirement:
+As a replacement for this module during an upgrade, there is a recipe that re-combines the content blocks into a single requirement:
 
 * [silverstripe/recipe-content-blocks](https://github.com/silverstripe/recipe-content-blocks)
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@ This repository contains a base set of CMS content blocks for the [silverstripe-
 
 ## Warning: deprecated!
 
+For ease of maintenance and the ability for developers to individually select functionality, this module was split into two separate ones containing the functionality of each of the contained blocks.
+
 For SilverStripe 4.2 or newer, please use one or both of the following modules instead:
 
 * [silverstripe/elemental-fileblock](https://github.com/silverstripe/silverstripe-elemental-fileblock)
 * [silverstripe/elemental-bannerblock](https://github.com/silverstripe/silverstripe-elemental-bannerblock)
 
-This module will only be accepting patch fixes to the `1.0` branch from now on.
+As a replacement for this module during an upgrade, there is now also a recipe that re-combines the content blocks into a single requirement:
+
+* [silverstripe/recipe-content-blocks](https://github.com/silverstripe/recipe-content-blocks)
+
+This module (`silverstripe/elemental-content-blocks`) will only be accepting patch fixes to the `1.0` branch from now on.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "silverstripe/elemental-blocks",
     "description": "A collection of CMS blocks for the silverstripe-elemental module",
     "type": "silverstripe-vendormodule",
+    "abandoned": "silverstripe/recipe-content-blocks",
     "keywords": [
         "silverstripe",
         "elemental",
@@ -19,6 +20,9 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "^3.0"
+    },
+    "suggest": {
+        "silverstripe/recipe-content-blocks": "Replaces the functionality of this module for SilverStripe 4.2 and above"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
People reading the deprecation notice were sometimes confused about what
steps to take next - as this module was replaced with a recipe after
it's components were split out, I think it fair to relay this
information to the user at the same time as the notice, along with hints
in the composer manifest. Hopefully this gives better direction on what
to do next in order to install an up to date set of packages for
elemental on newer SilverStripe versions.

Closes #45 